### PR TITLE
Add support for passing parameters into the configration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ configurations {
 mybatisGenerator {
     verbose = true
     configFile = 'src/main/resources/autogen/generatorConfig.xml'
-    
+
+    // optional, you can reference these parameters in the configration file, using the `${PARAM_NAME}` notation.
+    parameters username: 'example', password: '123456'
+
     // optional, here is the override dependencies for the plugin or you can add other database dependencies.
     dependencies {
         mybatisGenerator 'org.mybatis.generator:mybatis-generator-core:1.3.7'

--- a/src/functionalTest/groovy/com/thinkimi/gradle/MybatisGeneratorPluginFunctionTest.groovy
+++ b/src/functionalTest/groovy/com/thinkimi/gradle/MybatisGeneratorPluginFunctionTest.groovy
@@ -44,7 +44,7 @@ class MybatisGeneratorPluginFunctionTest extends Specification {
             repositories {
                 mavenCentral()
             }
-            
+
             configurations {
                 mybatisGenerator
             }
@@ -52,7 +52,7 @@ class MybatisGeneratorPluginFunctionTest extends Specification {
             mybatisGenerator {
                 verbose = true
                 configFile = 'build/functionalTest/src/main/resources/autogen/generatorConfig.xml'
-                
+                parameters username: 'thinkimi', password: '123456'
                 // optional, here is the override dependencies for the plugin or you can add other database dependencies.
                 dependencies {
                     mybatisGenerator 'org.mybatis.generator:mybatis-generator-core:1.3.7'

--- a/src/functionalTest/resources/autogen/generatorConfig.xml
+++ b/src/functionalTest/resources/autogen/generatorConfig.xml
@@ -17,8 +17,8 @@
         <jdbcConnection
                 driverClass="org.postgresql.Driver"
                 connectionURL="jdbc:postgresql://localhost:5435/postgres"
-                userId="thinkimi"
-                password="123456">
+                userId="${username}"
+                password="${password}">
         </jdbcConnection>
 
         <javaModelGenerator targetPackage="com.thinkimi.gradle.model" targetProject="build/functionalTest/src/main/java">

--- a/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorExtension.groovy
+++ b/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorExtension.groovy
@@ -11,7 +11,6 @@ class MybatisGeneratorExtension {
     def overwrite = true
     def configFile = "generatorConfig.xml"
     def verbose = false
-    def targetDir = "."
     def parameters = [:]
 
 }

--- a/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorExtension.groovy
+++ b/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorExtension.groovy
@@ -12,5 +12,6 @@ class MybatisGeneratorExtension {
     def configFile = "generatorConfig.xml"
     def verbose = false
     def targetDir = "."
+    def parameters = [:]
 
 }

--- a/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorPlugin.groovy
+++ b/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorPlugin.groovy
@@ -32,7 +32,6 @@ class MybatisGeneratorPlugin implements Plugin<ProjectInternal> {
             overwrite = { project.mybatisGenerator.overwrite }
             configFile = { project.mybatisGenerator.configFile }
             verbose = { project.mybatisGenerator.verbose }
-            targetDir = { project.mybatisGenerator.targetDir }
             parameters = { project.mybatisGenerator.parameters }
         }
     }

--- a/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorPlugin.groovy
+++ b/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorPlugin.groovy
@@ -33,6 +33,7 @@ class MybatisGeneratorPlugin implements Plugin<ProjectInternal> {
             configFile = { project.mybatisGenerator.configFile }
             verbose = { project.mybatisGenerator.verbose }
             targetDir = { project.mybatisGenerator.targetDir }
+            parameters = { project.mybatisGenerator.parameters }
         }
     }
 

--- a/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorTask.groovy
+++ b/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorTask.groovy
@@ -23,8 +23,6 @@ class MybatisGeneratorTask extends ConventionTask {
     @Internal
     def verbose
     @Internal
-    def targetDir
-    @Internal
     Map parameters
     @Internal
     FileCollection mybatisGeneratorClasspath
@@ -33,8 +31,6 @@ class MybatisGeneratorTask extends ConventionTask {
     void executeCargoAction() {
         services.get(IsolatedAntBuilder).withClasspath(getMybatisGeneratorClasspath()).execute {
             ant.taskdef(name: 'mbgenerator', classname: 'org.mybatis.generator.ant.GeneratorAntTask')
-
-            ant.properties['generated.source.dir'] = getTargetDir()
             parameters.each { ant.property(name: it.key, value: it.value) }
             ant.mbgenerator(overwrite: getOverwrite(), configfile: getConfigFile(), verbose: getVerbose()) {
                 propertyset {

--- a/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorTask.groovy
+++ b/src/main/groovy/com/thinkimi/gradle/MybatisGeneratorTask.groovy
@@ -25,6 +25,8 @@ class MybatisGeneratorTask extends ConventionTask {
     @Internal
     def targetDir
     @Internal
+    Map parameters
+    @Internal
     FileCollection mybatisGeneratorClasspath
 
     @TaskAction
@@ -33,7 +35,12 @@ class MybatisGeneratorTask extends ConventionTask {
             ant.taskdef(name: 'mbgenerator', classname: 'org.mybatis.generator.ant.GeneratorAntTask')
 
             ant.properties['generated.source.dir'] = getTargetDir()
-            ant.mbgenerator(overwrite: getOverwrite(), configfile: getConfigFile(), verbose: getVerbose())
+            parameters.each { ant.property(name: it.key, value: it.value) }
+            ant.mbgenerator(overwrite: getOverwrite(), configfile: getConfigFile(), verbose: getVerbose()) {
+                propertyset {
+                    parameters.each { propertyref(name: it.key) }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
fix #15 

You can set parameters \(by name and value\) and pass into the MBG's configuration file via Ant's property.

```groovy
// build.gradle

mybatisGenerator {
  // set parameters as Map
  parameters 'jdbc.url'     : 'jdbc:postgresql...',
             'jdbc.username': '...',
             'jdbc.password': '...'
}
```

```xml
<!-- generatorConfig.xml -->

<!-- reference the parameters by using ${...} -->
<jdbcConnection driverClass="org.postgresql.Driver"
                connectionURL="${jdbc.url}"
                userId="${jdbc.username}"
                password="${jdbc.password}" />
```

An existing similar config `targetDir` \(passing a parameter as `generated.source.dir` \) was not functioning and undocumented config, so I've removed.
